### PR TITLE
Minor improvements for NeatBrain + fix types for evolvim-tools

### DIFF
--- a/evolvim-lib/src/lib/brain/mod.rs
+++ b/evolvim-lib/src/lib/brain/mod.rs
@@ -37,3 +37,22 @@ pub trait RecombinationInfinite {
     where
         Self: NeuralNet + std::marker::Sized;
 }
+
+pub trait ProvideInformation {
+    fn get_raw_values(&self) -> Vec<String> {
+        vec!(String::from("This struct has not yet implemented it's own information system."))
+    }
+
+    fn get_keys(&self) -> Vec<String> {
+        vec!(String::from("warning"))
+    }
+
+    fn get_ordered_key_value_pairs(&self) -> Vec<(String, String)> {
+        let values = self.get_raw_values();
+        let keys = self.get_keys();
+        assert!(values.len() == keys.len(), "The amount of values ({}) and keys ({}) in the implementation of ProvideInformation does not match.", values.len(), keys.len());
+        
+        // Zip the two iterators
+        keys.into_iter().zip(values.into_iter()).collect()
+    }
+}

--- a/evolvim-lib/src/lib/neat/mod.rs
+++ b/evolvim-lib/src/lib/neat/mod.rs
@@ -80,6 +80,22 @@ impl crate::brain::RecombinationInfinite for NeatBrain {
     }
 }
 
+impl crate::brain::ProvideInformation for NeatBrain {
+    fn get_keys(&self) -> Vec<String> {
+        vec!(
+            "nodes".to_string(),
+            "connections".to_string()
+        )
+    }
+
+    fn get_raw_values(&self) -> Vec<String> {
+        vec!(
+            format!("{}", self.genome.get_node_genome().len()),
+            format!("{}", self.genome.get_connection_genome().len())
+        )
+    }
+}
+
 // TODO: serialize the values of the nodes (which allows for memory)
 impl serde::Serialize for NeatBrain {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {

--- a/evolvim-lib/src/lib/neat/phenotype/generate.rs
+++ b/evolvim-lib/src/lib/neat/phenotype/generate.rs
@@ -6,9 +6,9 @@ use std::collections::HashMap;
 impl From<&Genome> for NeuralNet {
     fn from(genome: &Genome) -> Self {
         let node_gen = genome.get_node_genome();
-        let mut nodes: Vec<Node> = std::iter::repeat(Node::empty())
+        let mut nodes: Box<[Node]> = std::iter::repeat(Node::empty())
             .take(node_gen.len())
-            .collect();
+            .collect::<Vec<Node>>().into_boxed_slice();
         let mut inputs = Vec::new();
         // Preallocate the memory so we don't have to reallocate and make the *mut-pointers invalid.
         let mut outputs = Vec::with_capacity(
@@ -58,7 +58,7 @@ impl From<&Genome> for NeuralNet {
         NeuralNet {
             nodes,
             inputs,
-            outputs,
+            outputs: outputs.into_boxed_slice(),
         }
     }
 }

--- a/evolvim-lib/src/lib/neat/phenotype/mod.rs
+++ b/evolvim-lib/src/lib/neat/phenotype/mod.rs
@@ -6,9 +6,9 @@ use super::output::OutputType;
 // TODO: use unsafe pointers or something to speed things up
 #[derive(Debug)]
 pub struct NeuralNet {
-    nodes: Vec<Node>,
+    nodes: Box<[Node]>,
 
-    outputs: Vec<Output>,
+    outputs: Box<[Output]>,
     inputs: Vec<Input>,
 }
 
@@ -20,18 +20,18 @@ impl NeuralNet {
     }
 
     pub fn use_output(&self, env: &mut crate::brain::EnvironmentMut, time_step: f64) {
-        for output in &self.outputs {
+        for output in self.outputs.iter() {
             output.use_output(env, time_step);
         }
     }
 
     pub fn run_calculations(&mut self) {
-        for n in &mut self.outputs {
+        for n in self.outputs.iter_mut() {
             // Reset the value to 0
             n.value = 0.0;
         }
 
-        for n in &mut self.nodes {
+        for n in self.nodes.iter_mut() {
             n.calc();
         }
     }

--- a/evolvim-tools/src/cli.rs
+++ b/evolvim-tools/src/cli.rs
@@ -6,6 +6,9 @@ use clap::{App, Arg};
 use lib_evolvim::Board;
 use std::sync::atomic::Ordering;
 
+// type BrainType = lib_evolvim::neat::NeatBrain;
+type BrainType = lib_evolvim::Brain;
+
 fn main() {
     let abort_reader = std::sync::Arc::new(std::sync::atomic::ATOMIC_BOOL_INIT);
     let abort_writer = abort_reader.clone();
@@ -63,8 +66,8 @@ fn main() {
         matches.value_of("output")
     };
 
-    let mut board = if let Some(name) = matches.value_of("input") {
-        Board::load_from(name).unwrap()
+    let mut board: Board<BrainType> = if let Some(name) = matches.value_of("input") {
+        Board::<BrainType>::load_from(name).unwrap()
     } else {
         Board::default()
     };

--- a/evolvim-tools/src/main/graphics/mod.rs
+++ b/evolvim-tools/src/main/graphics/mod.rs
@@ -261,13 +261,15 @@ pub trait DrawableBrain {
 }
 
 impl DrawableBrain for lib_evolvim::neat::NeatBrain {
-    fn draw_brain<C, G>(&self, _context: Context, _graphics: &mut G, _glyphs: &mut C)
+    fn draw_brain<C, G>(&self, context: Context, graphics: &mut G, glyphs: &mut C)
     where
         C: CharacterCache,
         C::Error: Debug,
         G: Graphics<Texture = C::Texture>,
     {
-        unimplemented!();
+        let text = Text::new(18);
+        let info = self.get_ordered_key_value_pairs().into_iter().map(|(key, value)| format!("{}: {}", key, value)).collect();
+        draw_lines(info, 20.0, 100.0, context, text, glyphs, graphics);
     }
 }
 

--- a/evolvim-tools/src/main/graphics/view.rs
+++ b/evolvim-tools/src/main/graphics/view.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::BrainType;
 use std::ops::Range;
 
 /// The view part of MVC (Model-View-Controller), currently takes on jobs for the controller too.
@@ -19,7 +20,7 @@ pub struct View {
     _base_tile_width: f64,
     tile_width: f64,
 
-    pub board: Board,
+    pub board: Board<BrainType>,
 
     pub mouse: MouseCoordinate,
 

--- a/evolvim-tools/src/main/mod.rs
+++ b/evolvim-tools/src/main/mod.rs
@@ -9,6 +9,9 @@ use clap::{App, Arg};
 use lib_evolvim::Board;
 use piston_window::*;
 
+// type BrainType = lib_evolvim::neat::NeatBrain;
+type BrainType = lib_evolvim::brain::Brain;
+
 fn main() {
     let matches = App::new("Evolvim - GUI launched via CLI")
         .version(clap::crate_version!())
@@ -42,7 +45,7 @@ fn main() {
 
     let mut view = View::default();
     if let Some(filename) = matches.value_of("input") {
-        view.board = Board::load_from(filename).unwrap();
+        view.board = Board::<BrainType>::load_from(filename).unwrap();
     }
 
     let output_file = if matches.is_present("save") {


### PR DESCRIPTION
bc71238 replaces the `Vec`s used by NeatBrain with boxed slices, this is to ensure no elements get added or removed from the `Vec` which can cause use-after-free and other bugs because of the reallocation.